### PR TITLE
Remove unnecessary escape in Regex.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -331,5 +331,5 @@ utils.last = function(arr, n) {
 };
 
 utils.escapeRegex = function(str) {
-  return str.replace(/\\?([!^*?()\[\]{}+?/])/g, '\\$1');
+  return str.replace(/\\?([!^*?()[\]{}+?/])/g, '\\$1');
 };


### PR DESCRIPTION
Unless it's a stylistic thing or something.