### PR TITLE
Fix Option for CVE-2024-4068: Memory Exhaustion in Braces

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -39,6 +39,22 @@ const parse = (input, options = {}) => {
     throw new SyntaxError(`Input length (${input.length}), exceeds max characters (${max})`);
   }
 
+  let braceStack = [];
+  for (const char of input) {
+    if (char === '{') {
+      braceStack.push('{');
+    } else if (char === '}') {
+      if (braceStack.length === 0) {
+        throw new SyntaxError("Mismatched closing brace found");
+      }
+      braceStack.pop();
+    }
+  }
+  
+  if (braceStack.length > 0) {
+    throw new SyntaxError("Mismatched open brace found");
+  }
+
   let ast = { type: 'root', input, nodes: [] };
   let stack = [ast];
   let block = ast;


### PR DESCRIPTION
Proposing as a possible solution if it fits.

Issue Description:  "braces" fails to limit the number of characters it can handle, which could lead to Memory Exhaustion. In "lib/parse.js," if a malicious user sends "imbalanced braces" as input, the parsing will enter a loop, which will cause the program to start allocating heap memory without freeing it at any moment of the loop. Eventually, the JavaScript heap limit is reached, and the program will crash.

To address this issue I added a check for imbalanced braces after the maxLength check. When tested it no longer leads to "Javascript heap out of memory" and will instead throw syntax error when imbalanced braces are used similar to when input is above the max length.