### PR TITLE
Adds GitHub Actions CI, removes `.travis.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os:
-  - linux
-  - osx
-  - windows
-language: node_js
-node_js:
-  - node
-  - '10'
-  - '8'


### PR DESCRIPTION
Hi folks,

Was catching up on dependency updates and noticed #41; this PR is a quick attempt to add GitHub Actions CI that runs `npm test` across:

- LTS node versions - currently 18, 20, and 22
- latest versions of ubuntu, macOS, and windows

My fork has Actions enabled, so you can [see the workflow this file generated](https://github.com/mattxwang/braces/actions/runs/9650892202); everything seems to work as intended, and overall time is pretty short (~ 10-40s across all nine combinations).

I also removed the (probably unused?) `.travis.yml` file. 

Let me know if you've got any feedback and/or if there are other steps I should do (e.g. sign a CLA). Thanks!

---

(should close #41)