### PR TITLE
Several improvements for GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [8.3.0, 8, 10, 12, 14, 16, 18, 20, 22]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [8.3.0, 8, 10, 12, 14, 16, 18, 20, 22]
         os: [ ubuntu-latest, macos-latest, windows-latest ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,11 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node-version: [8.3.0, 8, 10, 12, 14, 16, 18, 20, 22]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-
-    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha -r ./test/mocha-initialization.js",
     "benchmark": "node benchmark"
   },
   "dependencies": {

--- a/test/braces.parse.js
+++ b/test/braces.parse.js
@@ -16,7 +16,7 @@ describe('braces.parse()', () => {
     it('should return an AST', () => {
       const ast = parse('a/{b,c}/d');
       const brace = ast.nodes.find(node => node.type === 'brace');
-      assert(brace);
+      assert.ok(brace);
       assert.equal(brace.nodes.length, 5);
     });
 
@@ -30,7 +30,7 @@ describe('braces.parse()', () => {
       const ast = parse('a/{a,b,[{c,d}]}/e');
       const brace = ast.nodes[2];
       const bracket = brace.nodes.find(node => node.value[0] === '[');
-      assert(bracket);
+      assert.ok(bracket);
       assert.equal(bracket.value, '[{c,d}]');
     });
   });

--- a/test/mocha-initialization.js
+++ b/test/mocha-initialization.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview
+ * This package works with node@8.3.0, which does not have support for `assert.strict`.
+ * This module is a shim to support these methods.
+ *
+ * @todo Remove this file when we drop support for node@8.3.0.
+ */
+const assert = require('assert');
+
+if (assert.strict === undefined) {
+  assert.strict = {
+    ok: assert.ok,
+    equal: assert.equal,
+    deepEqual: assert.deepEqual,
+    throws: assert.throws,
+  };
+}


### PR DESCRIPTION
There are several improvements for CI after #47:

1. Running CI on all supported versions of the platform.
1. Running CI only on Ubuntu, as this package does not use OS-specific methods.
1. Do not cancel CI jobs when the first job falls.
1. Fixed CI for node@8.3.0 (the minimum supported version of nodejs due to the spread operator usage in the code).